### PR TITLE
Only send board change

### DIFF
--- a/client-web/src/reducers/reducer_board.js
+++ b/client-web/src/reducers/reducer_board.js
@@ -13,7 +13,6 @@ export default function(state = defaultState, action) {
       for (var i = 0; i < state.length; i++) {
         newState[i] = state[i].slice();
       }
-      console.log(newState);
 
       // update newState
       newState[action.payload.locationY][action.payload.locationX].status = action.payload.status;

--- a/client-web/src/reducers/reducer_board.js
+++ b/client-web/src/reducers/reducer_board.js
@@ -3,7 +3,23 @@ var defaultState = require('./initialBoardState');
 
 export default function(state = defaultState, action) {
   if (action.type === 'UPDATE-BOARD') {
-      return action.payload;
+    if (action.payload.type === 0) {
+      // if payload.type is 0, we are receiving the whole board
+      return action.payload.board;
+    } else if (action.payload.type === 1) {
+      // we are receiving the changes of the board, do some local calculation
+      // step 1: deep copy state, which is two dimensional array
+      var newState = [];
+      for (var i = 0; i < state.length; i++) {
+        newState[i] = state[i].slice();
+      }
+      console.log(newState);
+
+      // update newState
+      newState[action.payload.locationY][action.payload.locationX].status = action.payload.status;
+
+      return newState;
+    }
   }
   return state;
 }

--- a/index.js
+++ b/index.js
@@ -39,7 +39,9 @@ io.on('connection', function(socket){
   });
 
   socket.on('getNewBoard', function() {
-    io.emit('updateBoard', gameManager.rooms[roomName].board.board);  // to send stuff back to client side
+    //type 0 means that sending the whole board
+    //type 1 means that sending the changes
+    io.emit('updateBoard', {type: 0, board: gameManager.rooms[roomName].board.board});  // to send stuff back to client side
     io.emit('countMines', gameManager.rooms[roomName].board.minesLeft);
   });
 

--- a/socket-helpers/dropFlagHandler.js
+++ b/socket-helpers/dropFlagHandler.js
@@ -13,22 +13,24 @@ module.exports = function(io, board, currentScores, data) {
       board.minesLeft--;
       console.log('mines left: ', board.minesLeft);
       io.emit('countMines', board.minesLeft);
-      io.emit('updateBoard', board.board);
+      // only send the change of the board, make sure it's type 1
+      io.emit('updateBoard', {type: 1, locationX: location.x, locationY: location.y, status: 1});
       // update currentScores then emit the change
       updateCurrentScores(currentScores, {id: playerId, scoreChange: scoreRightFlag});
       io.emit('updateScore', {id: playerId, scoreChange: scoreRightFlag});
     } else {
     // if the flag is dropped at a wrong place
       board.board[location.y][location.x].status = 3;
-      //update board
-      io.emit('updateBoard', board.board);
+      // only send the change of the board, make sure it's type 1
+      io.emit('updateBoard', {type: 1, locationX: location.x, locationY: location.y, status: 3});
       // update currentScores then emit the change
       updateCurrentScores(currentScores, {id: playerId, scoreChange: scoreWrongFlag});
       io.emit('updateScore', {id: playerId, scoreChange: scoreWrongFlag});
       //after 0.3, reset the corresponing grid to initial
       setTimeout(() => {
         board.board[location.y][location.x].status = 0;
-        io.emit('updateBoard', board.board);
+        // only send the change of the board, make sure it's type 1
+        io.emit('updateBoard', {type: 1, locationX: location.x, locationY: location.y, status: 0});
       }, 300);
     }
     if (board.minesLeft === 0){

--- a/socket-helpers/openSpaceHandler.js
+++ b/socket-helpers/openSpaceHandler.js
@@ -24,9 +24,10 @@ module.exports = function(io, board, currentScores, data) {
     if (board.minesLeft === 0){
       board.generate();
       setTimeout(function(){
-        io.emit('updateBoard', board.board);
+        io.emit('updateBoard', {type: 0, board: board.board});
       }, 300);
     }
   }
-  io.emit('updateBoard', board.board);
+  // only send the change of the board, make sure it's type 1
+  io.emit('updateBoard', {type: 1, locationX: location.x, locationY: location.y, status: 2});
 }


### PR DESCRIPTION
simplify communication
-[x]: when creating a new board or a new gamer joins, we provide the info of the whole board
-[x]: when some minor changes happen, server only send back the change of the board, calculation will be done locally